### PR TITLE
Version 9.x, Sandbox fixes, and hardware decoding fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.flatpak-builder
+builddir
+repo
+
+.idea

--- a/com.nomachine.nxplayer.metainfo.xml
+++ b/com.nomachine.nxplayer.metainfo.xml
@@ -9,25 +9,20 @@
   <summary>Access NoMachine computers over the network</summary>
 
   <description>
-    <p>Enterprise Client enables fast and secure access to your remote PC or desktop computer where you have installed one of the NoMachine server products. It provides a powerful connection interface, named the NoMachine Player, packed with all the features you need to work with your remote desktop. This package is available for those who prefer just a standalone "client-side" application, either because regulatory requirements dictate that connecting clients must stay as thin clients, or simply because a scaled-down client app is your personal preference. It's free to download and can be used to connect remotely from any Windows, Linux, Mac, ARM or Raspberry device to a computer where you have installed a NoMachine Enterprise product or the NoMachine Free Edition.</p>
-    <p>NOTE: This wrapper is not verified by, affiliated with, or supported by NoMachine.</p>
+    <p>The NoMachine Enterprise Client enables fast and secure access to your remote PC or desktop computer where you have installed one of the NoMachine server products. It provides a powerful connection interface—NoMachine Player—packed with all the features needed to work with your remote desktop.</p>
+    <p>This standalone client-side application is ideal for users seeking a lightweight remote desktop solution or meeting regulatory constraints that prohibit full server installations. It supports connections to systems running NoMachine Enterprise or the Free Edition, and is available for Windows, Linux, macOS, ARM, and Raspberry Pi devices.</p>
+    <p><b>Disclaimer:</b> This Flatpak wrapper is not verified by, affiliated with, or supported by NoMachine S.à r.l.</p>
   </description>
 
   <developer id="com.nomachine">
-    <name translate="no">NoMachine S.à r.l.</name>
+    <name>NoMachine S.à r.l.</name>
   </developer>
-
-  <supports>
-    <control>pointing</control>
-    <control>keyboard</control>
-    <control>touch</control>
-  </supports>
 
   <launchable type="desktop-id">com.nomachine.nxplayer.desktop</launchable>
 
   <screenshots>
     <screenshot type="default">
-      <caption>Machines</caption>
+      <caption>Main interface</caption>
       <image>https://github.com/flathub/com.nomachine.nxplayer/raw/master/screenshots/nxplayer.png</image>
     </screenshot>
   </screenshots>
@@ -37,12 +32,22 @@
 
   <categories>
     <category>Network</category>
+    <category>RemoteAccess</category>
   </categories>
 
+  <content_rating type="oars-1.1"/>
+
   <releases>
-    <release version="8.11.3" date="2024-01-30"/>
+    <release version="9.0.188_11" date="2025-05-23"/>
   </releases>
 
+  <provides>
+    <binary>nxplayer</binary>
+  </provides>
 
-  <content_rating type="oars-1.1"/>
+  <supports>
+    <control>keyboard</control>
+    <control>pointing</control>
+    <control>touch</control>
+  </supports>
 </component>

--- a/com.nomachine.nxplayer.metainfo.xml
+++ b/com.nomachine.nxplayer.metainfo.xml
@@ -9,20 +9,25 @@
   <summary>Access NoMachine computers over the network</summary>
 
   <description>
-    <p>The NoMachine Enterprise Client enables fast and secure access to your remote PC or desktop computer where you have installed one of the NoMachine server products. It provides a powerful connection interface—NoMachine Player—packed with all the features needed to work with your remote desktop.</p>
-    <p>This standalone client-side application is ideal for users seeking a lightweight remote desktop solution or meeting regulatory constraints that prohibit full server installations. It supports connections to systems running NoMachine Enterprise or the Free Edition, and is available for Windows, Linux, macOS, ARM, and Raspberry Pi devices.</p>
-    <p><b>Disclaimer:</b> This Flatpak wrapper is not verified by, affiliated with, or supported by NoMachine S.à r.l.</p>
+    <p>Enterprise Client enables fast and secure access to your remote PC or desktop computer where you have installed one of the NoMachine server products. It provides a powerful connection interface, named the NoMachine Player, packed with all the features you need to work with your remote desktop. This package is available for those who prefer just a standalone "client-side" application, either because regulatory requirements dictate that connecting clients must stay as thin clients, or simply because a scaled-down client app is your personal preference. It's free to download and can be used to connect remotely from any Windows, Linux, Mac, ARM or Raspberry device to a computer where you have installed a NoMachine Enterprise product or the NoMachine Free Edition.</p>
+    <p>NOTE: This wrapper is not verified by, affiliated with, or supported by NoMachine.</p>
   </description>
 
   <developer id="com.nomachine">
-    <name>NoMachine S.à r.l.</name>
+    <name translate="no">NoMachine S.à r.l.</name>
   </developer>
+
+  <supports>
+    <control>pointing</control>
+    <control>keyboard</control>
+    <control>touch</control>
+  </supports>
 
   <launchable type="desktop-id">com.nomachine.nxplayer.desktop</launchable>
 
   <screenshots>
     <screenshot type="default">
-      <caption>Main interface</caption>
+      <caption>Machines</caption>
       <image>https://github.com/flathub/com.nomachine.nxplayer/raw/master/screenshots/nxplayer.png</image>
     </screenshot>
   </screenshots>
@@ -32,22 +37,12 @@
 
   <categories>
     <category>Network</category>
-    <category>RemoteAccess</category>
   </categories>
-
-  <content_rating type="oars-1.1"/>
 
   <releases>
     <release version="9.0.188_11" date="2025-05-23"/>
   </releases>
 
-  <provides>
-    <binary>nxplayer</binary>
-  </provides>
 
-  <supports>
-    <control>keyboard</control>
-    <control>pointing</control>
-    <control>touch</control>
-  </supports>
+  <content_rating type="oars-1.1"/>
 </component>

--- a/com.nomachine.nxplayer.yml
+++ b/com.nomachine.nxplayer.yml
@@ -1,60 +1,76 @@
 app-id: com.nomachine.nxplayer
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 separate-locales: false
 command: launch_nxplayer
+
 tags:
   - proprietary
+  - network
+  - remote-desktop
 
 finish-args:
   - --device=dri
+  - --device=input
+  - --device=usb
+  - --filesystem=xdg-desktop
   - --filesystem=xdg-documents
   - --filesystem=xdg-download
-  - --persist=.nx
+  - --filesystem=xdg-music
+  - --filesystem=xdg-pictures
+  - --filesystem=xdg-videos
+  - --filesystem=~/.nx:create
+  - --filesystem=~/.ssh:ro
   - --share=ipc
   - --share=network
   - --socket=pulseaudio
   - --socket=x11
+  - --socket=ssh-auth
+  - --socket=cups
+  - --socket=pcsc
 
 modules:
-  - name: nomachine
+  - name: nomachine-enterprise-client
     buildsystem: simple
     build-commands:
-      - install -D $FLATPAK_ID.png $FLATPAK_DEST/share/icons/hicolor/256x256/apps/$FLATPAK_ID.png
-      - install -D $FLATPAK_ID.desktop $FLATPAK_DEST/share/applications/$FLATPAK_ID.desktop
-      - install -D $FLATPAK_ID.metainfo.xml $FLATPAK_DEST/share/metainfo/$FLATPAK_ID.metainfo.xml
-      - install -D apply_extra $FLATPAK_DEST/bin/apply_extra
-      - install -D launch_nxplayer $FLATPAK_DEST/bin/launch_nxplayer
+      - install -D com.nomachine.nxplayer.png /app/share/icons/hicolor/256x256/apps/com.nomachine.nxplayer.png
+      - install -D com.nomachine.nxplayer.desktop /app/share/applications/com.nomachine.nxplayer.desktop
+      - install -D com.nomachine.nxplayer.metainfo.xml /app/share/metainfo/com.nomachine.nxplayer.metainfo.xml
+      - install -D apply_extra /app/bin/apply_extra
+      - install -D launch_nxplayer /app/bin/launch_nxplayer
     sources:
       - type: extra-data
         only-arches:
           - x86_64
-        url: https://download.nomachine.com/download/8.14/Linux/nomachine-enterprise-client_8.14.2_1_x86_64.tar.gz
-        sha256: 5ad62132d2b160383e498e145c5486c27572c869c137a934d03a421173acc4c9
+        url: https://download.nomachine.com/download/9.0/Linux/nomachine-enterprise-client_9.0.188_11_x86_64.tar.gz
+        sha256: 12da61ef41b6dc4cf53a86a7d63071ac2da9d12f4e37fe47f2f22a71bc19dd9e
         filename: nomachine-enterprise-client.tar.gz
-        size: 43704225
-        # https://downloads.nomachine.com/download/?id=15
+        size: 62044936
+
       - type: extra-data
         only-arches:
           - aarch64
-        url: https://download.nomachine.com/download/8.14/Arm/nomachine-enterprise-client_8.14.2_1_aarch64.tar.gz
+        url: https://download.nomachine.com/download/9.0/Arm/nomachine-enterprise-client_9.0.188_11_aarch64.tar.gz
         sha256: ebb375aedfa95772a8d2e5a61ba7257189fccc019c237ffe17f040edbd0a2b45
         filename: nomachine-enterprise-client.tar.gz
-        size: 39983198
-        # https://downloads.nomachine.com/download/?id=86&distro=ARM
+        size: 57440036
+
       - type: file
         path: data/com.nomachine.nxplayer.png
+
       - type: file
         path: data/com.nomachine.nxplayer.desktop
+
       - type: file
         path: com.nomachine.nxplayer.metainfo.xml
+
       - type: script
         dest-filename: apply_extra
         commands:
-          - tar -xf nomachine-enterprise-client.tar.gz --strip-components 0
-          - NX_INSTALL_PREFIX=/app/extra ./NX/nxclient --install fedora > /dev/null
-            2>&1
+          - tar -xf nomachine-enterprise-client.tar.gz --strip-components=0
+          - NX_INSTALL_PREFIX=/app/extra ./NX/nxclient --install fedora > /dev/null 2>&1
+
       - type: script
         dest-filename: launch_nxplayer
         commands:

--- a/com.nomachine.nxplayer.yml
+++ b/com.nomachine.nxplayer.yml
@@ -68,8 +68,10 @@ modules:
       - type: script
         dest-filename: apply_extra
         commands:
-          - tar -xf nomachine-enterprise-client.tar.gz --strip-components=0
-          - NX_INSTALL_PREFIX=/app/extra ./NX/nxclient --install fedora > /dev/null 2>&1
+          - |
+            tar -xf nomachine-enterprise-client.tar.gz --strip-components=0
+            NX_INSTALL_PREFIX=/app/extra ./NX/nxclient --install fedora > /dev/null 2>&1
+            rm /app/extra/NX/lib/libstdc++.so.6 #remove the bundled libstdc++.so.6 to avoid conflicts with runtime libs
 
       - type: script
         dest-filename: launch_nxplayer

--- a/com.nomachine.nxplayer.yml
+++ b/com.nomachine.nxplayer.yml
@@ -11,8 +11,7 @@ tags:
   - remote-desktop
 
 finish-args:
-  - --device=dri
-  - --device=all # For backward compatibility, in the future we should use 'input' and 'usb'
+  - --device=all # For backward compatibility, in the future we should use 'dri', 'input', and 'usb'
   - --filesystem=xdg-desktop
   - --filesystem=xdg-documents
   - --filesystem=xdg-download
@@ -33,11 +32,11 @@ modules:
   - name: nomachine-enterprise-client
     buildsystem: simple
     build-commands:
-      - install -D com.nomachine.nxplayer.png /app/share/icons/hicolor/256x256/apps/com.nomachine.nxplayer.png
-      - install -D com.nomachine.nxplayer.desktop /app/share/applications/com.nomachine.nxplayer.desktop
-      - install -D com.nomachine.nxplayer.metainfo.xml /app/share/metainfo/com.nomachine.nxplayer.metainfo.xml
-      - install -D apply_extra /app/bin/apply_extra
-      - install -D launch_nxplayer /app/bin/launch_nxplayer
+      - install -D $FLATPAK_ID.png $FLATPAK_DEST/share/icons/hicolor/256x256/apps/$FLATPAK_ID.png
+      - install -D $FLATPAK_ID.desktop $FLATPAK_DEST/share/applications/$FLATPAK_ID.desktop
+      - install -D $FLATPAK_ID.metainfo.xml $FLATPAK_DEST/share/metainfo/$FLATPAK_ID.metainfo.xml
+      - install -D apply_extra $FLATPAK_DEST/bin/apply_extra
+      - install -D launch_nxplayer $FLATPAK_DEST/bin/launch_nxplayer
     sources:
       - type: extra-data
         only-arches:

--- a/com.nomachine.nxplayer.yml
+++ b/com.nomachine.nxplayer.yml
@@ -12,8 +12,7 @@ tags:
 
 finish-args:
   - --device=dri
-  - --device=input
-  - --device=usb
+  - --device=all # For backward compatibility, in the future we should use 'input' and 'usb'
   - --filesystem=xdg-desktop
   - --filesystem=xdg-documents
   - --filesystem=xdg-download

--- a/data/com.nomachine.nxplayer.desktop
+++ b/data/com.nomachine.nxplayer.desktop
@@ -1,9 +1,9 @@
 [Desktop Entry]
-Encoding=UTF-8
+Name=NoMachine Enterprise Client
 Comment=Access NoMachine computers over the network
 Exec=launch_nxplayer
 Icon=com.nomachine.nxplayer
-Name=NoMachine
-StartupWMClass=nxplayer.bin
+Terminal=false
 Type=Application
-Categories=Network;
+Categories=Network;RemoteAccess;
+StartupWMClass=nxplayer.bin


### PR DESCRIPTION
I didn't intend initially for this PR to be as big as it is, but after lots of trial and error I was able to finally fix hardware accelerated video decoding not working. Likewise, my patches update the base runtime to 24.08, and I make a number of alterations to the default sandboxing parameters to allow for better out-of-the-box compatibility.

The biggest of the changes is exposing  `~/.nx` directly to NoMachine, rather than using `--persist=.nx` which puts the .NX directory in ~/.var/app/com.nomachine.nxplayer/.nx, which is a non-standard location. Given that the client itself expects the config directory to be at ~/.nx, documentation describes it at ~/.nx, and those coming from traditional package installs will have theirs located at ~/.nx, it seems appropriate to honor that path.

Likewise, I also have exposed read-only the `~/.ssh` directory, as when you configure NoMachine to use the native SSH protocol rather than its bundled version, you need to be able to access this folder for your SSH config, known_hosts, keys, etc. For many people, we have to do this in order to tunnel SSH connections using ProxyJump configs to get through organizational bastion hosts.